### PR TITLE
Match module paths

### DIFF
--- a/src/__tests__/matchers.test.js
+++ b/src/__tests__/matchers.test.js
@@ -22,6 +22,12 @@ describe('generateIncludes', () => {
     expect(anymatch(includes, '/users/pierre/project/node_modules/@scoped/something/sub/test.js')).toBe(true);
   });
 
+  test('should match module paths', () => {
+    expect(anymatch(includes, '/users/pierre/project/node_modules/shared')).toBe(true);
+    expect(anymatch(includes, '/users/pierre/project/node_modules/and-another')).toBe(true);
+    expect(anymatch(includes, '/users/pierre/project/node_modules/@scoped/something')).toBe(true);
+  })
+
   test('should NOT match unreferenced modules', () => {
     expect(anymatch(includes, '/users/pierre/project/node_modules/and-yet-another/test.js')).toBe(false);
   });

--- a/src/next-transpile-modules.js
+++ b/src/next-transpile-modules.js
@@ -18,7 +18,10 @@ const regexEqual = (x, y) => {
 };
 
 const generateIncludes = (modules) => {
-  return [new RegExp(`(${modules.map(safePath).join('|')})${PATH_DELIMITER}(?!.*node_modules)`)];
+  return [
+    new RegExp(`(${modules.map(safePath).join('|')})$`),
+    new RegExp(`(${modules.map(safePath).join('|')})${PATH_DELIMITER}(?!.*node_modules)`)
+  ];
 };
 
 const generateExcludes = (modules) => {


### PR DESCRIPTION
I tried to upgrade this module in my project and stuck with not
transpiled code. After a few hours I got that before testing full
paths, webpack can test module path first. And it worked.

Can't run tests locally so rely on CI.