### PR TITLE
fix: absolute paths on windows

### DIFF
--- a/src/next-transpile-modules.js
+++ b/src/next-transpile-modules.js
@@ -36,7 +36,7 @@ const generateExcludes = (modules) => {
  * On Windows, the Regex won't match as Webpack tries to resolve the
  * paths of the modules. So we need to check for \\ and /
  */
-const safePath = (module) => module.split('/').join(PATH_DELIMITER);
+const safePath = (module) => module.split(/[\\\/]/g).join(PATH_DELIMITER);
 
 /**
  * Actual Next.js plugin


### PR DESCRIPTION
Fix for: https://github.com/martpie/next-transpile-modules/issues/75

This commit allows to pass absolute paths instead of modules. This allows to use transpilation with yarn pnp and next js on windows.

### Usage with yarn 2:
##### next.config.js

```
/** 
 * This script mark for transpilation all workspaces in repo.
 * For more info about pnpapi visit:
 * https://yarnpkg.com/advanced/pnpapi
 */
const pnpapi = require("pnpapi");

const currentWorkspaceLocator = pnpapi.findPackageLocator(__filename);
const topLevelWorkspaceLocator = pnpapi.findPackageLocator(
  pnpapi.getPackageInformation(pnpapi.topLevel).packageLocation
);

const allOtherWorkspaces = pnpapi
  .getDependencyTreeRoots()
  .filter(
    p =>
      p.reference !== currentWorkspaceLocator.reference &&
      p.reference !== topLevelWorkspaceLocator.reference
  );

const packagesInformation = allOtherWorkspaces.map(pnpapi.getPackageInformation);

// map to absolute paths
const modulesToTranspile = packagesInformation.map(pkgInfo => pkgInfo.packageLocation);

const withTM = require("next-transpile-modules")(modulesToTranspile);

module.exports = withTM();
```