### PR TITLE
feat: support .mjs extension

### DIFF
--- a/src/next-transpile-modules.js
+++ b/src/next-transpile-modules.js
@@ -79,7 +79,7 @@ const withTmInitializer = (transpileModules = []) => {
 
         // Add a rule to include and parse all modules (js & ts)
         config.module.rules.push({
-          test: /\.+(js|jsx|ts|tsx)$/,
+          test: /\.+(js|jsx|mjs|ts|tsx)$/,
           loader: options.defaultLoaders.babel,
           include: includes
         });


### PR DESCRIPTION
Aligning with Next's config here, adding support for the `.mjs` extension.

https://github.com/zeit/next.js/blob/b8d075ef0e68b8407644b17813c510b4e30fd9ff/packages/next/build/webpack-config.ts#L677