### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ module.exports = withTM({
 });
 ```
 
-### I have trouble with duplicated dependencies
+### I have trouble with duplicated dependencies or the `Invalid hook call` error in `react`
 
 It can happen that when using `next-transpile-modules` with a local package and `npm`, you end up with duplicated dependencies in your final Next.js build. It is important to understand _why_ it happens.
 
@@ -233,6 +233,6 @@ module.exports = withTM({
 });
 ```
 
-Please note, the above [will only work](https://github.com/zeit/next.js/issues/9022#issuecomment-610255555) if `react` is properly declared as a `peerDependencies` or `devDependecy` in your referenced package.
+Please note, the above [will only work](https://github.com/zeit/next.js/issues/9022#issuecomment-610255555) if `react` is properly declared as `peerDependencies` or `devDependencies` in your referenced package.
 
 It is not a great solution, but it works. Any help to find a more future-proof solution is welcome.

--- a/README.md
+++ b/README.md
@@ -233,4 +233,6 @@ module.exports = withTM({
 });
 ```
 
+Please note, the above [will only work](https://github.com/zeit/next.js/issues/9022#issuecomment-610255555) if `react` is properly declared as a `peerDependencies` or `devDependecy` in your referenced package.
+
 It is not a great solution, but it works. Any help to find a more future-proof solution is welcome.


### PR DESCRIPTION
Clarification about how to get `useHooks` error to go away.