### PR TITLE
fix: enable HMR and disable cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "next-transpile-modules",
-  "version": "4.1.0",
+  "name": "@module-federation/next-transpile-modules",
+  "version": "4.1.2",
   "main": "src/next-transpile-modules.js",
   "license": "MIT",
   "author": "Pierre de la Martinière <pierre.de.la.martiniere@gmail.com>",

--- a/src/next-transpile-modules.js
+++ b/src/next-transpile-modules.js
@@ -183,7 +183,6 @@ const withTmInitializer = (transpileModules = [], options = {}) => {
             managedPaths: managed
           };
         }
-
         // Overload the Webpack config if it was already overloaded
         if (typeof nextConfig.webpack === 'function') {
           return nextConfig.webpack(config, options);

--- a/src/next-transpile-modules.js
+++ b/src/next-transpile-modules.js
@@ -168,7 +168,14 @@ const withTmInitializer = (transpileModules = [], options = {}) => {
         }
 
         if (isWebpack5) {
-          config.cache = false;
+          const managed = transpileModules.map((mod) => {
+            return path.dirname(require.resolve(mod));
+          });
+
+          config.cache = {
+            type: 'memory',
+            managedPaths: managed
+          };
         }
 
         // Overload the Webpack config if it was already overloaded

--- a/src/next-transpile-modules.js
+++ b/src/next-transpile-modules.js
@@ -167,6 +167,10 @@ const withTmInitializer = (transpileModules = [], options = {}) => {
           }
         }
 
+        if (isWebpack5) {
+          config.cache = false;
+        }
+
         // Overload the Webpack config if it was already overloaded
         if (typeof nextConfig.webpack === 'function') {
           return nextConfig.webpack(config, options);
@@ -183,7 +187,9 @@ const withTmInitializer = (transpileModules = [], options = {}) => {
         // https://github.com/zeit/next.js/blob/815f2e91386a0cd046c63cbec06e4666cff85971/packages/next/server/hot-reloader.js#L335
 
         const ignored = isWebpack5
-          ? config.watchOptions.ignored.concat(transpileModules)
+          ? config.watchOptions.ignored
+              .concat(transpileModules.map((i) => '**/node_modules/!(' + i + ')*/**'))
+              .filter((i) => i !== '**/node_modules/**')
           : config.watchOptions.ignored
               .filter((pattern) => !regexEqual(pattern, /[\\/]node_modules[\\/]/) && pattern !== '**/node_modules/**')
               .concat(excludes);

--- a/src/next-transpile-modules.js
+++ b/src/next-transpile-modules.js
@@ -168,9 +168,15 @@ const withTmInitializer = (transpileModules = [], options = {}) => {
         }
 
         if (isWebpack5) {
-          const managed = transpileModules.map((mod) => {
-            return path.dirname(require.resolve(mod));
-          });
+          const managed = transpileModules.reduce((acc, mod) => {
+            try {
+              // tests dont have valid package.json field to resolve modules
+              acc.push(path.dirname(require.resolve(mod)));
+            } catch (e) {
+              console.warn('Unable to resolve module', mod);
+            }
+            return acc;
+          }, []);
 
           config.cache = {
             type: 'memory',


### PR DESCRIPTION
Using glob pattern to ignore transpiled modules, disabling webpack cache as it messes with node_modules rebuilds 

resolves #112 