### PR TITLE
Replace pkg-dir with escalade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3608,6 +3608,11 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -8734,54 +8739,6 @@
         "node-modules-regexp": "^1.0.0"
       }
     },
-    "pkg-dir": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
-      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
-      "requires": {
-        "find-up": "^5.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-          "requires": {
-            "locate-path": "^6.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-          "requires": {
-            "p-locate": "^5.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "requires": {
-            "yocto-queue": "^0.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-          "requires": {
-            "p-limit": "^3.0.2"
-          }
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-        }
-      }
-    },
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
@@ -12103,11 +12060,6 @@
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
       }
-    },
-    "yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   ],
   "dependencies": {
     "enhanced-resolve": "^5.3.2",
-    "pkg-dir": "^5.0.0"
+    "escalade": "^3.1.1"
   },
   "devDependencies": {
     "@types/jest-environment-puppeteer": "4.4.0",

--- a/src/__tests__/__apps__/pnpm/pnpm-lock.yaml
+++ b/src/__tests__/__apps__/pnpm/pnpm-lock.yaml
@@ -10,7 +10,7 @@ dependencies:
 devDependencies:
   '@types/react': 16.9.55
   '@types/react-dom': 16.9.9
-lockfileVersion: 5.1
+lockfileVersion: 5.2
 packages:
   /@ampproject/toolbox-core/2.6.1:
     dependencies:
@@ -1202,7 +1202,7 @@ packages:
       source-map: 0.8.0-beta.0
       stacktrace-parser: 0.1.10
       strip-ansi: 6.0.0
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
     dev: false
     peerDependencies:
       react: ^16.9.0 || ^17
@@ -1213,7 +1213,7 @@ packages:
   /@next/react-refresh-utils/10.0.0_66609d456e1c4fc52398fef065f8d988:
     dependencies:
       react-refresh: 0.8.3
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
     dev: false
     peerDependencies:
       react-refresh: 0.8.3
@@ -1425,18 +1425,14 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
-  /ajv-errors/1.0.1:
+  /ajv-errors/1.0.1_ajv@6.12.6:
+    dependencies:
+      ajv: 6.12.6
     dev: false
     peerDependencies:
       ajv: '>=5.0.0'
     resolution:
       integrity: sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
-  /ajv-keywords/3.5.2:
-    dev: false
-    peerDependencies:
-      ajv: ^6.9.1
-    resolution:
-      integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
   /ajv-keywords/3.5.2_ajv@6.12.6:
     dependencies:
       ajv: 6.12.6
@@ -2235,7 +2231,7 @@ packages:
       postcss-value-parser: 4.1.0
       schema-utils: 2.7.1
       semver: 7.3.2
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
     dev: false
     engines:
       node: '>= 10.13.0'
@@ -3779,7 +3775,7 @@ packages:
       vm-browserify: 1.1.2
       watchpack: 2.0.0-beta.13
       web-vitals: 0.2.4
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
       webpack-sources: 1.4.3
     dev: false
     engines:
@@ -4602,7 +4598,7 @@ packages:
       sass: 1.28.0
       schema-utils: 2.7.1
       semver: 7.3.2
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
     dev: false
     engines:
       node: '>= 10.13.0'
@@ -4639,8 +4635,8 @@ packages:
   /schema-utils/1.0.0:
     dependencies:
       ajv: 6.12.6
-      ajv-errors: 1.0.1
-      ajv-keywords: 3.5.2
+      ajv-errors: 1.0.1_ajv@6.12.6
+      ajv-keywords: 3.5.2_ajv@6.12.6
     dev: false
     engines:
       node: '>= 4'
@@ -4982,7 +4978,7 @@ packages:
     dependencies:
       loader-utils: 2.0.0
       schema-utils: 2.7.1
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
     dev: false
     engines:
       node: '>= 8.9.0'
@@ -5093,7 +5089,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.0
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     dev: false
@@ -5406,7 +5402,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
-  /webpack/4.44.1_webpack@4.44.1:
+  /webpack/4.44.1:
     dependencies:
       '@webassemblyjs/ast': 1.9.0
       '@webassemblyjs/helper-module-context': 1.9.0
@@ -5436,7 +5432,6 @@ packages:
       node: '>=6.11.5'
     hasBin: true
     peerDependencies:
-      webpack: '*'
       webpack-cli: '*'
       webpack-command: '*'
     peerDependenciesMeta:

--- a/src/__tests__/__apps__/pnpm/pnpm-lock.yaml
+++ b/src/__tests__/__apps__/pnpm/pnpm-lock.yaml
@@ -10,7 +10,7 @@ dependencies:
 devDependencies:
   '@types/react': 16.9.55
   '@types/react-dom': 16.9.9
-lockfileVersion: 5.2
+lockfileVersion: 5.1
 packages:
   /@ampproject/toolbox-core/2.6.1:
     dependencies:
@@ -1202,7 +1202,7 @@ packages:
       source-map: 0.8.0-beta.0
       stacktrace-parser: 0.1.10
       strip-ansi: 6.0.0
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
     dev: false
     peerDependencies:
       react: ^16.9.0 || ^17
@@ -1213,7 +1213,7 @@ packages:
   /@next/react-refresh-utils/10.0.0_66609d456e1c4fc52398fef065f8d988:
     dependencies:
       react-refresh: 0.8.3
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
     dev: false
     peerDependencies:
       react-refresh: 0.8.3
@@ -1425,14 +1425,18 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
-  /ajv-errors/1.0.1_ajv@6.12.6:
-    dependencies:
-      ajv: 6.12.6
+  /ajv-errors/1.0.1:
     dev: false
     peerDependencies:
       ajv: '>=5.0.0'
     resolution:
       integrity: sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
+  /ajv-keywords/3.5.2:
+    dev: false
+    peerDependencies:
+      ajv: ^6.9.1
+    resolution:
+      integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
   /ajv-keywords/3.5.2_ajv@6.12.6:
     dependencies:
       ajv: 6.12.6
@@ -2231,7 +2235,7 @@ packages:
       postcss-value-parser: 4.1.0
       schema-utils: 2.7.1
       semver: 7.3.2
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
     dev: false
     engines:
       node: '>= 10.13.0'
@@ -3775,7 +3779,7 @@ packages:
       vm-browserify: 1.1.2
       watchpack: 2.0.0-beta.13
       web-vitals: 0.2.4
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
       webpack-sources: 1.4.3
     dev: false
     engines:
@@ -4598,7 +4602,7 @@ packages:
       sass: 1.28.0
       schema-utils: 2.7.1
       semver: 7.3.2
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
     dev: false
     engines:
       node: '>= 10.13.0'
@@ -4635,8 +4639,8 @@ packages:
   /schema-utils/1.0.0:
     dependencies:
       ajv: 6.12.6
-      ajv-errors: 1.0.1_ajv@6.12.6
-      ajv-keywords: 3.5.2_ajv@6.12.6
+      ajv-errors: 1.0.1
+      ajv-keywords: 3.5.2
     dev: false
     engines:
       node: '>= 4'
@@ -4978,7 +4982,7 @@ packages:
     dependencies:
       loader-utils: 2.0.0
       schema-utils: 2.7.1
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
     dev: false
     engines:
       node: '>= 8.9.0'
@@ -5089,7 +5093,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.0
-      webpack: 4.44.1
+      webpack: 4.44.1_webpack@4.44.1
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     dev: false
@@ -5402,7 +5406,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
-  /webpack/4.44.1:
+  /webpack/4.44.1_webpack@4.44.1:
     dependencies:
       '@webassemblyjs/ast': 1.9.0
       '@webassemblyjs/helper-module-context': 1.9.0
@@ -5432,6 +5436,7 @@ packages:
       node: '>=6.11.5'
     hasBin: true
     peerDependencies:
+      webpack: '*'
       webpack-cli: '*'
       webpack-command: '*'
     peerDependenciesMeta:

--- a/src/next-transpile-modules.js
+++ b/src/next-transpile-modules.js
@@ -51,7 +51,6 @@ const getPackageRootDirectory = (module) => {
   try {
     // Get the module path
     packageDirectory = resolve(CWD, module);
-    console.log('packageDirectory 2', packageDirectory);
 
     if (!packageDirectory) {
       throw new Error(

--- a/src/next-transpile-modules.js
+++ b/src/next-transpile-modules.js
@@ -2,7 +2,7 @@ const path = require('path');
 const process = require('process');
 
 const enhancedResolve = require('enhanced-resolve');
-const pkgDir = require('pkg-dir');
+const escalade = require('escalade/sync');
 
 // Use me when needed
 // const util = require('util');
@@ -51,6 +51,7 @@ const getPackageRootDirectory = (module) => {
   try {
     // Get the module path
     packageDirectory = resolve(CWD, module);
+    console.log('packageDirectory 2', packageDirectory);
 
     if (!packageDirectory) {
       throw new Error(
@@ -60,7 +61,15 @@ const getPackageRootDirectory = (module) => {
 
     try {
       // Get the location of its package.json
-      packageRootDirectory = pkgDir.sync(packageDirectory);
+      const pkgPath = escalade(packageDirectory, (dir, names) => {
+        if (names.includes('package.json')) {
+          return 'package.json';
+        }
+        return false;
+      });
+      if (pkgPath != null) {
+        packageRootDirectory = path.dirname(pkgPath);
+      }
     } catch (err) {
       throw new Error(
         `next-transpile-modules - an error happened when trying to get the root directory of "${module}". Is it missing a package.json?\n${err}`

--- a/src/next-transpile-modules.js
+++ b/src/next-transpile-modules.js
@@ -58,22 +58,19 @@ const getPackageRootDirectory = (module) => {
       );
     }
 
-    try {
-      // Get the location of its package.json
-      const pkgPath = escalade(packageDirectory, (dir, names) => {
-        if (names.includes('package.json')) {
-          return 'package.json';
-        }
-        return false;
-      });
-      if (pkgPath != null) {
-        packageRootDirectory = path.dirname(pkgPath);
+    // Get the location of its package.json
+    const pkgPath = escalade(packageDirectory, (dir, names) => {
+      if (names.includes('package.json')) {
+        return 'package.json';
       }
-    } catch (err) {
+      return false;
+    });
+    if (pkgPath == null) {
       throw new Error(
         `next-transpile-modules - an error happened when trying to get the root directory of "${module}". Is it missing a package.json?\n${err}`
       );
     }
+    packageRootDirectory = path.dirname(pkgPath);
   } catch (err) {
     throw new Error(`next-transpile-modules - an unexpected error happened when trying to resolve "${module}"\n${err}`);
   }


### PR DESCRIPTION
Ref https://github.com/lukeed/escalade/

pkg-dir and many other Sindre's modules are bloated with dependencies.
For example I have 4 instances of pkg-dir and every its dependency in
my node_modules. Would be cool to replace them with
something smaller like escalade which is gonna be used in
webpack-plugin-serve, yargs and will be used in the next major
jest release.