### PR TITLE
Fix check for nested node_modules

### DIFF
--- a/src/next-transpile-modules.js
+++ b/src/next-transpile-modules.js
@@ -120,12 +120,16 @@ const withTmInitializer = (modules = [], options = {}) => {
 
     // Generate Webpack condition for the passed modules
     // https://webpack.js.org/configuration/module/#ruleinclude
-    const match = (path) => {
-      const lastEntry = path.split(`${path.sep}node_modules${path.sep}`).slice(-1)[0];
+    const match = (pathToMatch) => {
+      const isNestedNodeModules = (pathToMatch.match(/node_modules/g) || []).length > 1;
 
-      return modules.some((modulePath) => {
-        const transpiled = lastEntry.includes(modulePath);
-        if (transpiled) logger(`transpiled: ${path}`);
+      if (isNestedNodeModules) {
+        return false;
+      }
+
+      return modulesPaths.some((modulePath) => {
+        const transpiled = pathToMatch.includes(modulePath);
+        if (transpiled) logger(`transpiled: ${pathToMatch}`);
         return transpiled;
       });
     };


### PR DESCRIPTION
Based on what was being discussed here:
https://github.com/martpie/next-transpile-modules/issues/151#issuecomment-772486043

- `modulesPaths.some` as it was in versions prior to 6.1.0
-  Check the occurrences of "node_modules" inside the path of the module being analyzed, if ther are multiple, tell the module matcher to not consider to transpilation