### PR TITLE
fix: allow transpiling of explicit nested node_modules

### DIFF
--- a/src/next-transpile-modules.js
+++ b/src/next-transpile-modules.js
@@ -56,10 +56,13 @@ const createLogger = (enable) => {
  * @param {function} logger
  * @returns {(path: string) => boolean}
  */
- const createWebpackMatcher = (modulesToTranspile, logger = createLogger(false)) => {
+const createWebpackMatcher = (modulesToTranspile, logger = createLogger(false)) => {
   // create an array of tuples with each passed in module to transpile and its node_modules depth
   // example: ['/full/path/to/node_modules/button/node_modules/icon', 2]
-  const modulePathsWithDepth = modulesToTranspile.map(modulePath => [modulePath, (modulePath.match(/node_modules/g) || []).length])
+  const modulePathsWithDepth = modulesToTranspile.map((modulePath) => [
+    modulePath,
+    (modulePath.match(/node_modules/g) || []).length,
+  ]);
 
   return (filePath) => {
     const nodeModulesDepth = (filePath.match(/node_modules/g) || []).length;

--- a/src/next-transpile-modules.js
+++ b/src/next-transpile-modules.js
@@ -56,16 +56,17 @@ const createLogger = (enable) => {
  * @param {function} logger
  * @returns {(path: string) => boolean}
  */
-const createWebpackMatcher = (modulesToTranspile, logger = createLogger(false)) => {
+ const createWebpackMatcher = (modulesToTranspile, logger = createLogger(false)) => {
+  // create an array of tuples with each passed in module to transpile and its node_modules depth
+  // example: ['/full/path/to/node_modules/button/node_modules/icon', 2]
+  const modulePathsWithDepth = modulesToTranspile.map(modulePath => [modulePath, (modulePath.match(/node_modules/g) || []).length])
+
   return (filePath) => {
-    const isNestedNodeModules = (filePath.match(/node_modules/g) || []).length > 1;
+    const nodeModulesDepth = (filePath.match(/node_modules/g) || []).length;
 
-    if (isNestedNodeModules) {
-      return false;
-    }
-
-    return modulesToTranspile.some((modulePath) => {
-      const transpiled = filePath.startsWith(modulePath);
+    return modulePathsWithDepth.some(([modulePath, moduleDepth]) => {
+      // Ensure we aren't implicitly transpiling nested dependencies by comparing depths of modules to be transpiled and the module being checked
+      const transpiled = filePath.startsWith(modulePath) && nodeModulesDepth === moduleDepth;
       if (transpiled) logger(`transpiled: ${filePath}`);
       return transpiled;
     });


### PR DESCRIPTION
Based on [the docs](https://github.com/martpie/next-transpile-modules#scoped-packages), I would expect to be able to specify explicit nested dependencies and have them be transpiled. This doesn't seem to be the case, as any potential files that are nested more than one level deep are ignored based on this logic:
https://github.com/martpie/next-transpile-modules/blob/e7222640dd72c0b4702ba5abbe79e261182a454e/src/next-transpile-modules.js#L61-L65

I've updated the default matcher to explicitly check the depth of file passed into the matcher against the depths of the modules passed into `next-transpile-modules`. This should preserve the current behavior while also ensuring explicitly listed nested packages are transpiled.

I know there have been a few discussions and PRs around this (#151, #163, and #188 to name a few), but I believe this change would make it the most predictable for users.

Alternatively, we could provide our own `__unstable_matcher`, but I'm not sure what your plans are with that API. 😄 