### PR TITLE
ci: fix step comment for pnpm workspaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install tests apps dependencies (yarn workspaces symlinks)
         run: yarn --frozen-lockfile --cwd src/__tests__/__apps__/yarn-workspaces-symlinks
 
-      - name: Install tests apps dependencies (yarn workspaces)
+      - name: Install tests apps dependencies (pnpn workspaces)
         run: npx pnpm i --frozen-lockfile --prefix src/__tests__/__apps__/pnpm
 
       - name: Build test apps


### PR DESCRIPTION
Just a typo in the pnpm step message.

