### PR TITLE
Attempt to have ntm:source field support

### DIFF
--- a/src/__tests__/__apps__/yarn-workspaces/app/next.config.js
+++ b/src/__tests__/__apps__/yarn-workspaces/app/next.config.js
@@ -1,4 +1,4 @@
-const withTM = require('./next-transpile-modules')(['shared', 'shared-ts', 'shared-ui', 'lodash-es']);
+const withTM = require('./next-transpile-modules')(['shared', 'shared-ts', 'shared-ts-source', 'shared-ui', 'lodash-es']);
 
 module.exports = withTM({
   future: {

--- a/src/__tests__/__apps__/yarn-workspaces/app/package.json
+++ b/src/__tests__/__apps__/yarn-workspaces/app/package.json
@@ -18,6 +18,7 @@
     "sass": "^1.27.0",
     "shared": "^1.0.0",
     "shared-ts": "^1.0.0",
+    "shared-ts-source": "^1.0.0",
     "shared-ui": "^1.0.0"
   },
   "devDependencies": {

--- a/src/__tests__/__apps__/yarn-workspaces/package.json
+++ b/src/__tests__/__apps__/yarn-workspaces/package.json
@@ -3,6 +3,7 @@
   "workspaces": [
     "_shared",
     "_shared-ts",
+    "_shared-ts-source",
     "_shared-ui",
     "app"
   ]

--- a/src/__tests__/__packages__/_shared-ts-source/dist/index.js
+++ b/src/__tests__/__packages__/_shared-ts-source/dist/index.js
@@ -1,0 +1,5 @@
+// A fake dist folder to be sure that the source is resolved first
+// and not this one
+export const fakeAdd = (a, b) => a + b;
+export const fakeSubstract = (a, b) => a - b;
+export const fakeMultiply = (a, b) => a * b;

--- a/src/__tests__/__packages__/_shared-ts-source/main.js
+++ b/src/__tests__/__packages__/_shared-ts-source/main.js
@@ -1,0 +1,1 @@
+export default null;

--- a/src/__tests__/__packages__/_shared-ts-source/package-lock.json
+++ b/src/__tests__/__packages__/_shared-ts-source/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "shared-ts",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/src/__tests__/__packages__/_shared-ts-source/package.json
+++ b/src/__tests__/__packages__/_shared-ts-source/package.json
@@ -1,7 +1,8 @@
 {
   "name": "shared-ts-source",
   "version": "1.0.0",
-  "source": "main/index.ts",
+  "ntm:source": "src/calc.ts",
+  "source": "src/index.ts",
   "main": "dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/__tests__/__packages__/_shared-ts-source/package.json
+++ b/src/__tests__/__packages__/_shared-ts-source/package.json
@@ -1,7 +1,8 @@
 {
   "name": "shared-ts-source",
   "version": "1.0.0",
-  "main": "src/index.ts",
+  "source": "main/index.ts",
+  "main": "dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/src/__tests__/__packages__/_shared-ts-source/package.json
+++ b/src/__tests__/__packages__/_shared-ts-source/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "shared-ts-source",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/src/__tests__/__packages__/_shared-ts-source/src/calc.ts
+++ b/src/__tests__/__packages__/_shared-ts-source/src/calc.ts
@@ -1,0 +1,3 @@
+export const add = (a: number, b: number) => a + b;
+export const substract = (a: number, b: number) => a - b;
+export const multiply = (a: number, b: number) => a * b;

--- a/src/__tests__/__packages__/_shared-ts-source/src/index.ts
+++ b/src/__tests__/__packages__/_shared-ts-source/src/index.ts
@@ -1,0 +1,1 @@
+export * from './calc';


### PR DESCRIPTION
Source field convention try-out and console.logs... Probably just bad ideas

## Idea

In current NTM version, the main field package is used to locate the (shared) package sources.

This makes it harder to publish packages on npm, cause the field should be used to locate the 'build' files (dist folder).

An idea was to use the `source` field, which is a convention used by microbundle... But I think this is dangerous cause we can have unexpected scenarios with regular packages (living in node_modules).

Another idea is to have a specific field `ntm:source` to indicate the path of the transpilable source.

That's what I'm trying to figure out, but not sure I'll do.




