### PR TITLE
Add support for global CSS imports

### DIFF
--- a/src/__tests__/__files__/pages/test-global-css.jsx
+++ b/src/__tests__/__files__/pages/test-global-css.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Textarea from 'shared-ui/components/Textarea';
+
+import Box from '../components/Box';
+
+const HomePage = () => {
+  return (
+    <main>
+      <Textarea>My textarea</Textarea>
+      <Box />
+    </main>
+  );
+};
+
+export default HomePage;

--- a/src/__tests__/__files__/pages/test-global-scss.jsx
+++ b/src/__tests__/__files__/pages/test-global-scss.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Alert from 'shared-ui/components/Alert';
+
+import Box from '../components/Box';
+
+const HomePage = () => {
+  return (
+    <main>
+      <Alert>My alert</Alert>
+      <Box />
+    </main>
+  );
+};
+
+export default HomePage;

--- a/src/__tests__/__packages__/_shared-ui/components/Alert.jsx
+++ b/src/__tests__/__packages__/_shared-ui/components/Alert.jsx
@@ -1,0 +1,11 @@
+import './Alert.scss';
+
+function Alert(props) {
+  return (
+    <div id="#alert" className='alert'>
+      {props.children}
+    </div>
+  );
+}
+
+export default Alert;

--- a/src/__tests__/__packages__/_shared-ui/components/Alert.jsx
+++ b/src/__tests__/__packages__/_shared-ui/components/Alert.jsx
@@ -2,9 +2,9 @@ import './Alert.scss';
 
 function Alert(props) {
   return (
-    <div id="#alert" className='alert'>
+    <textarea className='alert'>
       {props.children}
-    </div>
+    </textarea>
   );
 }
 

--- a/src/__tests__/__packages__/_shared-ui/components/Alert.scss
+++ b/src/__tests__/__packages__/_shared-ui/components/Alert.scss
@@ -1,0 +1,4 @@
+.alert {
+    background: green;
+    color: white;
+}

--- a/src/__tests__/__packages__/_shared-ui/components/Textarea.css
+++ b/src/__tests__/__packages__/_shared-ui/components/Textarea.css
@@ -1,0 +1,4 @@
+.textarea {
+    background: green;
+    color: white;
+}

--- a/src/__tests__/__packages__/_shared-ui/components/Textarea.jsx
+++ b/src/__tests__/__packages__/_shared-ui/components/Textarea.jsx
@@ -1,0 +1,11 @@
+import './Textarea.css';
+
+function Textarea(props) {
+  return (
+    <textarea type='text' className='textarea'>
+      {props.children}
+    </textarea>
+  );
+}
+
+export default Textarea;

--- a/src/__tests__/integrations.test.js
+++ b/src/__tests__/integrations.test.js
@@ -90,6 +90,23 @@ describe.each([
     });
   });
 
+  describe('global CSS transpilation', () => {
+    test('pages using transpiled modules should be correctly displayed', async () => {
+      const page = await browser.newPage();
+      const response = await page.goto(`${BASE_URL}/test-global-css`);
+
+      if (!response) throw new Error('Could not access the page');
+
+      expect(response.status()).toBe(200);
+
+      const content = await page.$eval('textarea', (e) => e.textContent);
+      expect(content).toBe('My textarea');
+
+      const className = await page.$eval('textarea', (e) => e.classList[0]);
+      expect(className).toBe('textarea');
+    });
+  });
+
   describe('scss-module transpilation', () => {
     test('pages using transpiled modules should be correctly displayed', async () => {
       const page = await browser.newPage();
@@ -101,6 +118,23 @@ describe.each([
 
       const className = await page.$eval('input', (e) => e.classList[0]);
       expect(className.includes('Input_input__')).toBe(true);
+    });
+  });
+
+  describe('global SASS transpilation', () => {
+    test('pages using transpiled modules should be correctly displayed', async () => {
+      const page = await browser.newPage();
+      const response = await page.goto(`${BASE_URL}/test-global-scss`);
+
+      if (!response) throw new Error('Could not access the page');
+
+      expect(response.status()).toBe(200);
+
+      const content = await page.$eval('#alert', (e) => e.textContent);
+      expect(content).toBe('My alert');
+
+      const className = await page.$eval('#alert', (e) => e.classList[0]);
+      expect(className).toBe('alert');
     });
   });
 });

--- a/src/__tests__/integrations.test.js
+++ b/src/__tests__/integrations.test.js
@@ -130,10 +130,10 @@ describe.each([
 
       expect(response.status()).toBe(200);
 
-      const content = await page.$eval('#alert', (e) => e.textContent);
+      const content = await page.$eval('textarea', (e) => e.textContent);
       expect(content).toBe('My alert');
 
-      const className = await page.$eval('#alert', (e) => e.classList[0]);
+      const className = await page.$eval('textarea', (e) => e.classList[0]);
       expect(className).toBe('alert');
     });
   });

--- a/src/next-transpile-modules.js
+++ b/src/next-transpile-modules.js
@@ -198,7 +198,6 @@ const withTmInitializer = (modules = [], options = {}) => {
             'This plugin is not compatible with Next.js versions below 5.0.0 https://err.sh/next-plugins/upgrade'
           );
         }
-
         if (resolveSymlinks !== undefined) {
           // Avoid Webpack to resolve transpiled modules path to their real path as
           // we want to test modules from node_modules only. If it was enabled,
@@ -319,8 +318,8 @@ const withTmInitializer = (modules = [], options = {}) => {
           );
 
           if (nextGlobalCssLoader) {
-            const cond = [...nextGlobalCssLoader.issuer.and, { or: [matcher, ...nextGlobalCssLoader.issuer.not] }];
-            nextGlobalCssLoader.issuer = { and: cond };
+            nextGlobalCssLoader.issuer = { or: [matcher, nextGlobalCssLoader.issuer] };
+            nextGlobalCssLoader.include = { or: [...modulesPaths, nextGlobalCssLoader.include] };
           } else if (!options.isServer) {
             // Note that Next.js ignores global CSS imports on the server
             console.warn('next-transpile-modules - could not find default CSS rule, global CSS imports may not work');
@@ -333,10 +332,7 @@ const withTmInitializer = (modules = [], options = {}) => {
           // FIXME: SASS works only when using a custom _app.js file.
           // See https://github.com/vercel/next.js/blob/24c3929ec46edfef8fb7462a17edc767a90b5d2b/packages/next/build/webpack/config/blocks/css/index.ts#L211
           if (nextGlobalSassLoader) {
-            nextGlobalSassLoader.issuer.or = nextGlobalSassLoader.issuer.and
-              ? nextGlobalSassLoader.issuer.and.concat(matcher)
-              : matcher;
-            delete nextGlobalSassLoader.issuer.and;
+            nextGlobalSassLoader.issuer = { or: [matcher, nextGlobalSassLoader.issuer] };
           } else if (!options.isServer) {
             // Note that Next.js ignores global SASS imports on the server
             console.info('next-transpile-modules - global SASS imports only work with a custom _app.js file');


### PR DESCRIPTION
This pull request builds upon the work in #166 and adds support for transpiling packages that use Global CSS imports (e.g., [Patternfly 4](https://github.com/patternfly/patternfly-react)).

The change works by looking up  Next.js' existing Webpack rules for global CSS imports and modifying them to include the targeted modules in the rule (therefore bypassing the error loader).

Since Next.js itself does not support importing global CSS inside non-page components, it might be a good idea to put this functionality behind a feature flag. What do you think @martpie?