### PR TITLE
chore: mark `__unstable_matcher` option as optional

### DIFF
--- a/src/next-transpile-modules.js
+++ b/src/next-transpile-modules.js
@@ -81,7 +81,7 @@ const createWebpackMatcher = (modulesToTranspile, logger = createLogger(false)) 
 /**
  * Transpile modules with Next.js Babel configuration
  * @param {string[]} modules
- * @param {{resolveSymlinks?: boolean, debug?: boolean, __unstable_matcher: (path: string) => boolean}} options
+ * @param {{resolveSymlinks?: boolean, debug?: boolean, __unstable_matcher?: (path: string) => boolean}} options
  */
 const withTmInitializer = (modules = [], options = {}) => {
   const withTM = (nextConfig = {}) => {


### PR DESCRIPTION
marks `__unstable_matcher` option as optional