### PR TITLE
Clarify note about where the plugin should go

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ module.exports = withTM({
 
 **Notes:**
 
-- please declare `withTM` as your last plugin (the "most nested" one).
+- please declare `withTM` as your last plugin (the outermost one).
 - ~~make sure all your packages have [a valid `main` field](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#main).~~ (not needed anymore since `7.1.0`)
 - there is currently no way to transpile only parts of a package, it's all or nothing
 


### PR DESCRIPTION
Hello!

Regarding this note:
> please declare `withTM` as your last plugin (the "most nested" one).

It may just be me, but my interpretation of this note is contradicting:
* by "last plugin" i'm thinking the last plugin that should be applied i.e.
```js
module.exports = withTM(
  withSomeOtherPlugin(
    withYetAnotherPlugin(
      {...} // actual next config
    )
  )
);
``` 
* by "most nested" one, I'm thinking the opposite:
```js
module.exports = withSomeOtherPlugin(
  withYetAnotherPlugin(
    withTM(
      {...} // actual next config
    )
  )
);
```

Assuming the first example is the right way, I wanted to propose a small change to the README that I think clarifies this up (or maybe we can add an example such as the one above to help clarify?).