### PR TITLE
feat(typings): allow to preserve config type

### DIFF
--- a/src/next-transpile-modules.js
+++ b/src/next-transpile-modules.js
@@ -84,6 +84,11 @@ const createWebpackMatcher = (modulesToTranspile, logger = createLogger(false)) 
  * @param {{resolveSymlinks?: boolean, debug?: boolean, __unstable_matcher?: (path: string) => boolean}} options
  */
 const withTmInitializer = (modules = [], options = {}) => {
+  /**
+   * @template T
+   * @param { T } nextConfig
+   * @returns { T | undefined }
+   */
   const withTM = (nextConfig = {}) => {
     if (modules.length === 0) return nextConfig;
 


### PR DESCRIPTION
When composing multiple plugins, the type of nextConfig is lost. 

A typecheck error will be throw for user setting `// @ts-check` in strict mode in the next.config.[js|mjs].

Found the cause in the withTMInitializer typings

## Changed

After a `npm run typings`, the `src/next-transpile-modules.d.ts` will be

### Before

```typescript
declare function withTmInitializer(modules?: string[], options?: {
    resolveSymlinks?: boolean;
    debug?: boolean;
    __unstable_matcher?: (path: string) => boolean;
   // THE OLD ONE
}): (nextConfig?: {}) => {};
```

### After

```typescript
declare function withTmInitializer(modules?: string[], options?: {
    resolveSymlinks?: boolean;
    debug?: boolean;
    __unstable_matcher?: (path: string) => boolean;
   // THE NEW ONE, T IS INFERRED FROM ARGUMENT (nextConfig). Return is the same
}): <T>(nextConfig?: T) => T;
```

### A patch 

Used a patch to see if all works and it seems to be okay

```diff
diff --git a/src/next-transpile-modules.d.ts b/src/next-transpile-modules.d.ts
index 9fc7d0a28176b649fcadb6d1bd6859c72bca9595..c0ba96230af8dcc669f06af99da6d5226800c7b8 100644
--- a/src/next-transpile-modules.d.ts
+++ b/src/next-transpile-modules.d.ts
@@ -8,4 +8,4 @@ declare function withTmInitializer(modules?: string[], options?: {
     resolveSymlinks?: boolean;
     debug?: boolean;
     __unstable_matcher?: (path: string) => boolean;
-}): (nextConfig?: {}) => {};
+}): <T>(nextConfig?: T) => T;
```

Discovered in that P/R https://github.com/belgattitude/perso/pull/1015
