### PR TITLE
fix ReferenceError

### DIFF
--- a/src/next-transpile-modules.js
+++ b/src/next-transpile-modules.js
@@ -122,7 +122,7 @@ const withTmInitializer = (modules = [], options = {}) => {
      */
     const getPackageRootDirectory = (module) => {
       try {
-        packageLookupDirectory = resolve(CWD, path.join(module, 'package.json'));
+        const packageLookupDirectory = resolve(CWD, path.join(module, 'package.json'));
         return path.dirname(packageLookupDirectory);
       } catch (err) {
         throw new Error(


### PR DESCRIPTION
This small PR fixes a `ReferenceError` in the `getPackageRootDirectory` function, which tried to assign a value to an undeclared variable.